### PR TITLE
Added brew tap command for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Arch users can install `p2pvc-git` from [the AUR](https://aur.archlinux.org/pack
 
 #### OS X (with Homebrew):
 
+     brew tap homebrew/science
      brew install ncurses portaudio opencv
 
 #### OS X (with MacPorts):


### PR DESCRIPTION
This is required to be able to install opencv in OS X.
