### PR TITLE
uname -o option is not avaliable in Mac OS, use -s option instead, it…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRCS=$(wildcard $(SRCDIR)/*.c)
 OBJS=$(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS))
 
 CFLAGS+=-O2 -Wall
-ifeq ($(platform), GNU/Linux)
+ifeq ($(platform), Linux)
 CFLAGS+=-DPA_USE_ALSA
 else
 CFLAGS+=-DPA_USE_COREAUDIO

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJDIR=objs
 SRCDIR=src
 INCDIR=$(SRCDIR)/inc
 CFLAGS+=-I$(INCDIR)
-platform=$(shell uname -o)
+platform=$(shell uname -s)
 
 SRCS=$(wildcard $(SRCDIR)/*.c)
 OBJS=$(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS))


### PR DESCRIPTION
uname -o option is not avaliable in Mac OS, use -s option instead, it works on Linux and Mac
