### PR TITLE
Remove hardcode gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-CC=gcc
 OBJDIR=objs
 SRCDIR=src
 INCDIR=$(SRCDIR)/inc


### PR DESCRIPTION
No need to set CC to gcc.  Using $(CC) without setting it allows the system to use gcc by default, and also for clang users to still compile.

Also, would it be possible to add a release with a version?