### PR TITLE
Update README to deprecate science brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Arch users can install `p2pvc-git` from [the AUR](https://aur.archlinux.org/pack
 
 #### OS X (with Homebrew):
 
-     brew tap homebrew/science
      brew install ncurses portaudio opencv
 
 #### OS X (with MacPorts):


### PR DESCRIPTION
`Homebrew/homebrew-science` tap has been deprecated, remove it to reflect the status.